### PR TITLE
Additional configuration options and cleanup

### DIFF
--- a/status-light/const.py
+++ b/status-light/const.py
@@ -6,7 +6,7 @@ class Status(enum.Enum):
     # Webex
     active = 1
     call = 2
-    DoNotDisturb = 3
+    donotdisturb = 3
     inactive = 4
     meeting = 5
     pending = 6
@@ -16,10 +16,21 @@ class Status(enum.Enum):
     free = 8
     tentative = 9
     busy = 10
-    OutOfOffice = 11
-    WorkingElsewhere = 12
+    outofoffice = 11
+    workingelsewhere = 12
 
-OFF = [Status.inactive, Status.OutOfOffice, Status.unknown, Status.free]
-GREEN = [Status.active]
-ORANGE = [Status.busy, Status.tentative]
-RED = [Status.call, Status.DoNotDisturb, Status.meeting, Status.presenting]
+    def _missing_(self, value):
+        return self.unknown
+
+class Color(enum.Enum):
+    unknown = 'xxxxxx'
+
+    Red = 'ff0000'
+    Yellow = 'ffff00'
+    Orange = 'ff9000'
+    Green = '00ff00'
+    Blue = '0000f'
+
+    def _missing_(self, value):
+        return self.unknown
+

--- a/status-light/office365.py
+++ b/status-light/office365.py
@@ -39,15 +39,7 @@ class OfficeAPI:
             availabilityView = availability[0]["availabilityView"][0]
             logger.debug('Got availabilityView: %s', availabilityView)
 
-            # Issue #3: Handle all O365 Statuses
-            # The OutOfOffice status is returned as a string with spaces, unlike the rest of the statuses, so we need to treat it special
-            if availabilityView == 'out of office':
-                availabilityView = 'OutOfOffice'
-            # The WorkingElsewhere status is returned as a string with spaces, unlike the rest of the statuses, so we need to treat it special
-            if availabilityView == 'working elsewhere':
-                availabilityView = 'WorkingElsewhere'
-
-            return const.Status[availabilityView]
+            return const.Status[availabilityView.replace(' ','').lower()]
         except (SystemExit, KeyboardInterrupt):
             return const.Status.unknown
         except BaseException as e:

--- a/status-light/util.py
+++ b/status-light/util.py
@@ -1,0 +1,13 @@
+def ignore_exception(ignoreException = Exception, default = None):
+    """ Decorator for ignoring exception from a function
+    e.g.   @ignore_exception(DivideByZero)
+    e.g.2. ignore_exception(DivideByZero)(Divide)(2/0)
+    """
+    def dec(function):
+        def _dec(*args, **kwargs):
+            try:
+                return function(*args, **kwargs)
+            except ignoreException:
+                return default
+        return _dec
+    return dec


### PR DESCRIPTION
Closes #5: colors can now be selected using the _COLOR env variables, with a choice of the predefined Red, Green, Blue, Yellow, and Orange colors or an RGB hex value. Invalid or missing options will default to Green for Available, Red for Busy, and Orange for Scheduled.

Closes #6: status lists can be configured using the _STATUS env variables. Invalid values in a list (or missing lists) will default to [inactive, outofoffice, unknown, and free] for Off, [active] for Available, [busy, tentative] for Scheduled, and [call, donotdisturb, meeting, presenting, pending] for Busy.

Closes #13: brightness can be configured using the TUYA_BRIGHTNESS env variable, with a range between 32 and 255. Invalid or missing values will default to a brightness of 128.

Cleaned up inconsistent capitalization in the Status enum.
Added utility decorator for ignoring exceptions during int parsing (with an option to default)