### PR TITLE
Bugfix and library revert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pycryptodomex
 webexteamssdk
-tuyaface
+tuyaface==v1.1.7
 O365

--- a/status-light/webex.py
+++ b/status-light/webex.py
@@ -15,7 +15,7 @@ class WebexAPI:
     def getPersonStatus(self, personID):
         api = WebexTeamsAPI(access_token = self.botID)
         try:
-            return const.Status[api.people.get(personID).status]
+            return const.Status[api.people.get(personID).status.lower()]
         except (SystemExit, KeyboardInterrupt):
             pass
         except BaseException as e:


### PR DESCRIPTION
Fixes an enum issue with Webex: DoNotDisturb was failing to be found in the Status enum after we moved to all lowercase.

Rolls tuyaface back to v1.1.7, after a Broken Socket error appeared in v1.2.0 after multiple requests on the same interface.