### PR TITLE
Improve util.parse_enum usability

### DIFF
--- a/status-light/status-light.py
+++ b/status-light/status-light.py
@@ -62,9 +62,9 @@ if False in [localEnv.get_sources(), localEnv.get_tuya(), localEnv.get_colors(),
     sys.exit(1)
 
 # 23 - Make logging level configurable
-logger.info('Setting log level to %s', localEnv.log_level)
-print(datetime.now().strftime('[%Y-%m-%d %H:%M:%S]'),'Setting log level to', localEnv.log_level)
-logger.setLevel(localEnv.log_level)
+logger.info('Setting log level to %s', localEnv.log_level.name)
+print(datetime.now().strftime('[%Y-%m-%d %H:%M:%S]'),'Setting log level to', localEnv.log_level.name)
+logger.setLevel(localEnv.log_level.name)
 
 # Depending on the selected sources, get the environment
 webex_api = None

--- a/status-light/utility/env.py
+++ b/status-light/utility/env.py
@@ -168,8 +168,6 @@ class Environment:
         return self.sleep_seconds >= 5 and self.sleep_seconds <= 60
 
     def get_log_level(self):
-        # _parse_enum returns a list, so grab the first, and, hopefully
-        # only, element
         self.log_level = util.parse_enum(os.environ.get('LOGLEVEL', None),
-            enum.LogLevel, 'LOGLEVEL', self.log_level)[0]
+            enum.LogLevel, 'LOGLEVEL', self.log_level, value_is_list=False)
         return self.log_level is not None

--- a/status-light/utility/util.py
+++ b/status-light/utility/util.py
@@ -76,25 +76,27 @@ def parse_color(color_string, default):
         if not re.match('^[0-9A-Fa-f]{6}$', color_string) is None:
             temp_color = color_string
         else:
-            # _parse_enum returns a list of enums, so grab the first, and, hopefully
-            # only, element and then get the value (the actual hex color value)
-            temp_color = parse_enum(color_string, enum.Color, "parse_color", default)[0].value
+            # _parse_enum returns an enum, get the value (the actual hex color value)
+            temp_color = parse_enum(color_string, enum.Color, "parse_color", default,
+                value_is_list=False).value
     except BaseException as ex: # pylint: disable=broad-except
         logger.warning('Exception encountered during _parseColor: %s, using default: %s',
             ex, default)
         temp_color = default
     return temp_color
 
-def parse_enum(value_string, value_enum:Enum, description, default):
-    """Given a string and an enumeration, attempts to parse the string into a list of
-    enums."""
+def parse_enum(value_string, value_enum:Enum, description, default, value_is_list:bool = True):
+    """Given a string and an enumeration, attempts to parse the string into enums."""
     temp_value = default
     if value_string in [None, '']:
         return temp_value
 
     try:
-        temp_value = list(value_enum[value.upper().strip()]
-            for value in value_string.split(','))
+        if value_is_list:
+            temp_value = list(value_enum[value.upper().strip()]
+                for value in value_string.split(','))
+        else:
+            temp_value = value_enum[value_string.upper().strip()]
     except BaseException as ex: # pylint: disable=broad-except
         logger.warning('Exception encountered during parse_enum for %s: %s', description, ex)
         temp_value = default


### PR DESCRIPTION
`util.parse_enum` assumed everything sent to it was a list of enums, which caused issues when sending things like `LOGLEVEL` and any of the `COLOR` variables, since those are not lists. Added `value_is_list` to allow the function to return a single value instead of a list that would then need to be parsed by the caller.