### PR TITLE
[feat] ICS - Experimenting with Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 *.pyc
 .vscode/
 .devcontainer/
+.claude/
 build/
 dist/
 status-light/__pycache__

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,15 +46,15 @@ There is no formal test suite, linter configuration, or build system. Developmen
 **Calendar sources** (`sources/calendar/`):
 - `office365.py` - Microsoft Graph API free/busy
 - `google.py` - Google Calendar API free/busy
-- `ics.py` - ICS file support (in development)
+- `ics.py` - ICS/iCalendar file support (RFC 5545 compliant)
 
 ### Status Precedence
 
 Status determination follows a strict hierarchy:
 1. **Source priority:** Collaboration always wins over Calendar (except UNKNOWN/OFF)
 2. **Within collaboration:** Webex > Slack
-3. **Within calendar:** Office 365 > Google
-4. **Status priority:** Busy > Scheduled > Available > Off
+3. **Within calendar:** Office 365 > Google > ICS
+4. **Status priority:** Busy > Tentative/Scheduled > Available > Off
 
 ### Key Utilities
 
@@ -62,18 +62,20 @@ Status determination follows a strict hierarchy:
 - `utility/env.py` - Environment variable parsing and validation
 - `utility/util.py` - Helper functions including `get_env_or_secret()` for Docker secrets
 
-### Output Target
+### Output Targets
 
-`targets/tuya.py` - Controls Tuya smart bulbs with retry logic and connection management.
+- `targets/tuya.py` - Controls Tuya smart bulbs with retry logic and connection management
+- `targets/virtual.py` - Virtual light for testing (logs status changes, no hardware required)
 
 ## Configuration
 
 All configuration is via environment variables (no config files). Key categories:
 
-- **Sources:** `SOURCES` (comma-separated: webex, slack, office365, google)
-- **Authentication:** Platform-specific tokens/IDs (e.g., `WEBEX_PERSONID`, `SLACK_BOT_TOKEN`, `O365_APPID`)
+- **Sources:** `SOURCES` (comma-separated: webex, slack, office365, google, ics)
+- **Target:** `TARGET` (tuya or virtual; default: tuya)
+- **Authentication:** Platform-specific tokens/IDs (e.g., `WEBEX_PERSONID`, `SLACK_BOT_TOKEN`, `O365_APPID`, `ICS_URL`)
 - **Colors:** `AVAILABLE_COLOR`, `SCHEDULED_COLOR`, `BUSY_COLOR` (predefined names or 24-bit hex)
-- **Device:** `TUYA_DEVICE` (JSON with protocol, deviceid, ip, localkey)
+- **Device:** `TUYA_DEVICE` (JSON with protocol, deviceid, ip, localkey; required only when TARGET=tuya)
 - **Behavior:** `SLEEP_SECONDS`, `CALENDAR_LOOKAHEAD`, `LOGLEVEL`, `ACTIVE_DAYS`, `ACTIVE_HOURS_*`
 
 Secrets support `*_FILE` variants for Docker secrets integration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ There is no formal test suite, linter configuration, or build system. Developmen
 **Calendar sources** (`sources/calendar/`):
 - `office365.py` - Microsoft Graph API free/busy
 - `google.py` - Google Calendar API free/busy
-- `ics.py` - ICS/iCalendar file support (RFC 5545 compliant)
+- `ics.py` - ICS/iCalendar file support (RFC 5545 compliant, uses `icalendar` + `recurring-ical-events` for proper timezone and recurring event handling)
 
 ### Status Precedence
 
@@ -86,3 +86,15 @@ GitHub Actions (`.github/workflows/docker-image.yml`) builds multi-platform Dock
 - Platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64
 - Triggers: PRs to main (build only), pushes with `v*` tags (build + push to Docker Hub)
 - Published to: `portableprogrammer/status-light`
+
+## Documentation
+
+When making changes, update documentation **before** suggesting commits:
+- `README.md` - User-facing documentation for environment variables, setup, and usage
+- `CLAUDE.md` - Developer guidance for Claude Code (this file)
+
+Keep both files in sync with code changes, especially for:
+- New or modified environment variables
+- New dependencies in `requirements.txt`
+- Architecture changes (new sources, targets, utilities)
+- Configuration options

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Status-Light monitors user status across collaboration platforms (Webex, Slack) and calendars (Office 365, Google Calendar) to display the "busiest" status on a Tuya RGB LED smart bulb. The application runs as a continuous polling loop inside a Docker container.
+
+## Running the Application
+
+**Local execution:**
+```bash
+python -u status-light/status-light.py
+```
+
+**Docker (preferred):**
+```bash
+docker run -e SOURCES=webex,office365 -e WEBEX_PERSONID=... portableprogrammer/status-light
+```
+
+**Build Docker image locally:**
+```bash
+docker build -f Dockerfiles/Dockerfile -t status-light .
+```
+
+There is no formal test suite, linter configuration, or build system. Development testing is done manually through Docker.
+
+## Architecture
+
+### Core Application Flow
+
+`status-light/status-light.py` is the entry point containing the `StatusLight` class which:
+1. Validates environment variables and initializes configured sources
+2. Runs a continuous polling loop (configurable via `SLEEP_SECONDS`)
+3. Queries each enabled source for current status
+4. Applies status precedence rules to determine the "busiest" status
+5. Updates the Tuya smart light color accordingly
+6. Handles graceful shutdown via signal handlers (SIGHUP, SIGINT, SIGQUIT, SIGTERM)
+
+### Status Sources
+
+**Collaboration sources** (`sources/collaboration/`):
+- `webex.py` - Webex Teams presence API
+- `slack.py` - Slack presence with custom status emoji/text parsing
+
+**Calendar sources** (`sources/calendar/`):
+- `office365.py` - Microsoft Graph API free/busy
+- `google.py` - Google Calendar API free/busy
+- `ics.py` - ICS file support (in development)
+
+### Status Precedence
+
+Status determination follows a strict hierarchy:
+1. **Source priority:** Collaboration always wins over Calendar (except UNKNOWN/OFF)
+2. **Within collaboration:** Webex > Slack
+3. **Within calendar:** Office 365 > Google
+4. **Status priority:** Busy > Scheduled > Available > Off
+
+### Key Utilities
+
+- `utility/enum.py` - Status enumerations (CollaborationStatus, CalendarStatus, Color)
+- `utility/env.py` - Environment variable parsing and validation
+- `utility/util.py` - Helper functions including `get_env_or_secret()` for Docker secrets
+
+### Output Target
+
+`targets/tuya.py` - Controls Tuya smart bulbs with retry logic and connection management.
+
+## Configuration
+
+All configuration is via environment variables (no config files). Key categories:
+
+- **Sources:** `SOURCES` (comma-separated: webex, slack, office365, google)
+- **Authentication:** Platform-specific tokens/IDs (e.g., `WEBEX_PERSONID`, `SLACK_BOT_TOKEN`, `O365_APPID`)
+- **Colors:** `AVAILABLE_COLOR`, `SCHEDULED_COLOR`, `BUSY_COLOR` (predefined names or 24-bit hex)
+- **Device:** `TUYA_DEVICE` (JSON with protocol, deviceid, ip, localkey)
+- **Behavior:** `SLEEP_SECONDS`, `CALENDAR_LOOKAHEAD`, `LOGLEVEL`, `ACTIVE_DAYS`, `ACTIVE_HOURS_*`
+
+Secrets support `*_FILE` variants for Docker secrets integration.
+
+## CI/CD
+
+GitHub Actions (`.github/workflows/docker-image.yml`) builds multi-platform Docker images:
+- Platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64
+- Triggers: PRs to main (build only), pushes with `v*` tags (build + push to Docker Hub)
+- Published to: `portableprogrammer/status-light`

--- a/README.md
+++ b/README.md
@@ -328,11 +328,13 @@ In the example above, the Slack custom status would match (since it is a case-in
 
 ### **Tuya**
 
+**Note:** Tuya configuration is only required when [`TARGET`](#target) is set to `tuya` (the default). If using `TARGET=virtual`, you can skip this section.
+
 #### `TUYA_DEVICE`
 
-- *Required*
+- *Required if [`TARGET`](#target) is `tuya`*
 
-Status-Light requires a [Tuya](https://www.tuya.com/) device, which are white-boxed and sold under many brand names. For example, the Tuya light working in the current environment is an [Above Lights](http://alabovelights.com/) [Smart Bulb 9W, model AL1](http://alabovelights.com/pd.jsp?id=17).
+Status-Light supports [Tuya](https://www.tuya.com/) devices, which are white-boxed and sold under many brand names. For example, the Tuya light working in the current environment is an [Above Lights](http://alabovelights.com/) [Smart Bulb 9W, model AL1](http://alabovelights.com/pd.jsp?id=17).
 
 Status-Light uses the [tuyaface](https://github.com/TradeFace/tuyaface/) module for Tuya communication.
 
@@ -352,7 +354,7 @@ Example `TUYA_DEVICE` value:
 
 #### `TUYA_BRIGHTNESS`
 
-- *Optional*
+- *Optional, only valid if [`TARGET`](#target) is `tuya`*
 - Acceptable range: `32`-`255`
 - Default value: `128`
 

--- a/README.md
+++ b/README.md
@@ -480,6 +480,8 @@ Since Google has [deprecated](https://developers.googleblog.com/2022/02/making-o
 
 **Note:** See [`CALENDAR_LOOKAHEAD`](#calendar_lookahead) to configure lookahead timing for Calendar sources.
 
+Status-Light uses the [icalendar](https://github.com/collective/icalendar) and [recurring-ical-events](https://github.com/niccokunzmann/python-recurring-ical-events) libraries to parse ICS files. These libraries correctly handle recurring events and cross-timezone event matching (e.g., a Pacific time event will be correctly detected when running in Mountain time).
+
 Status-Light's ICS source implements RFC 5545 compliant status detection based on the `TRANSP` (transparency) and `STATUS` properties of calendar events:
 
 | Event Properties | Status-Light Status |

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
 slack-sdk
-icalevents
+icalendar
+recurring-ical-events

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
 slack-sdk
+icalevents

--- a/status-light/sources/calendar/ics.py
+++ b/status-light/sources/calendar/ics.py
@@ -7,7 +7,6 @@ ICS Calendar Source
 
 # Standard imports
 import os
-import os.path
 from datetime import datetime, timedelta, timezone
 import logging
 import urllib.request
@@ -160,7 +159,7 @@ class Ics:
             # Use icalevents to parse the cached file
             calendar_events = events(file=cache_path, start=start_time, end=end_time)
 
-            if not calendar_events or len(calendar_events) == 0:
+            if not calendar_events:
                 logger.debug('No events in lookahead window')
                 return enum.Status.FREE
 

--- a/status-light/sources/calendar/ics.py
+++ b/status-light/sources/calendar/ics.py
@@ -1,0 +1,143 @@
+"""Status-Light
+(c) 2020-2025 Nick Warner
+https://github.com/portableprogrammer/Status-Light/
+
+ICS Calendar Source
+"""
+
+# Standard imports
+import os
+import os.path
+from datetime import datetime, timedelta, timezone
+import logging
+import urllib.request
+
+# 3rd-party imports
+from icalevents.icalevents import events
+
+# Project imports
+from utility import enum
+
+logger = logging.getLogger(__name__)
+
+
+class Ics:
+    """Handles ICS Calendar"""
+
+    url: str = ''
+
+    cacheStore: str = '~'
+    cacheFile: str = 'status-light-ics-cache.ics'
+    cacheLifetime: int = 30
+
+    # 81 - Make calendar lookahead configurable
+    lookahead: int = 5
+
+    def _get_cache_path(self) -> str:
+        """Returns the full path to the cache file."""
+        return os.path.normpath(os.path.join(
+            os.path.expanduser(self.cacheStore),
+            self.cacheFile
+        ))
+
+    def _should_refresh_cache(self) -> bool:
+        """Checks if the cache file is stale or missing.
+
+        Returns True if the cache should be refreshed."""
+        cache_path = self._get_cache_path()
+
+        # If the file doesn't exist, we need to fetch
+        if not os.path.exists(cache_path):
+            logger.debug('Cache file does not exist: %s', cache_path)
+            return True
+
+        # Check if the file is older than the cache lifetime
+        try:
+            file_mtime = datetime.fromtimestamp(
+                os.stat(cache_path).st_mtime, tz=timezone.utc)
+            cache_expiry = datetime.now(timezone.utc) - timedelta(minutes=self.cacheLifetime)
+
+            if file_mtime < cache_expiry:
+                logger.debug('Cache file is stale (mtime: %s, expiry: %s)',
+                            file_mtime, cache_expiry)
+                return True
+
+            logger.debug('Cache file is still valid (mtime: %s)', file_mtime)
+            return False
+        except OSError as ex:
+            logger.warning('Error checking cache file: %s', ex)
+            return True
+
+    def _fetch_and_cache(self) -> bool:
+        """Downloads the ICS file and saves it to the cache.
+
+        Returns True on success, False on failure."""
+        cache_path = self._get_cache_path()
+
+        try:
+            logger.debug('Fetching ICS from URL: %s', self.url)
+
+            # Create cache directory if it doesn't exist
+            cache_dir = os.path.dirname(cache_path)
+            if cache_dir and not os.path.exists(cache_dir):
+                os.makedirs(cache_dir)
+
+            # Download the ICS file
+            with urllib.request.urlopen(self.url, timeout=30) as response:
+                ics_content = response.read()
+
+            # Write to cache file
+            with open(cache_path, 'wb') as cache_file:
+                cache_file.write(ics_content)
+
+            logger.debug('Successfully cached ICS file to: %s', cache_path)
+            return True
+
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.warning('Error fetching ICS file: %s', ex)
+            logger.exception(ex)
+            return False
+
+    def get_current_status(self) -> enum.Status:
+        """Retrieves the ICS calendar status within the lookahead period.
+
+        Returns BUSY if there are events in the lookahead window,
+        FREE if there are no events, or UNKNOWN on error."""
+        try:
+            # Refresh cache if needed
+            if self._should_refresh_cache():
+                if not self._fetch_and_cache():
+                    # If fetch fails but we have an old cache, try to use it
+                    cache_path = self._get_cache_path()
+                    if not os.path.exists(cache_path):
+                        logger.warning('No cached ICS file available')
+                        return enum.Status.UNKNOWN
+                    logger.warning('Using stale cache file due to fetch failure')
+
+            cache_path = self._get_cache_path()
+
+            # Get events within the lookahead window
+            start_time = datetime.now(timezone.utc)
+            end_time = start_time + timedelta(minutes=self.lookahead)
+
+            logger.debug('Checking for events between %s and %s', start_time, end_time)
+
+            # Use icalevents to parse the cached file
+            calendar_events = events(file=cache_path, start=start_time, end=end_time)
+
+            if calendar_events and len(calendar_events) > 0:
+                logger.debug('Found %d event(s) in lookahead window', len(calendar_events))
+                for event in calendar_events:
+                    logger.debug('Event: %s (%s - %s)',
+                                event.summary, event.start, event.end)
+                return enum.Status.BUSY
+            else:
+                logger.debug('No events in lookahead window, assuming Free')
+                return enum.Status.FREE
+
+        except (SystemExit, KeyboardInterrupt):
+            return enum.Status.UNKNOWN
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.warning('Exception while getting ICS status: %s', ex)
+            logger.exception(ex)
+            return enum.Status.UNKNOWN

--- a/status-light/status-light.py
+++ b/status-light/status-light.py
@@ -17,7 +17,7 @@ import time
 
 # Project imports
 # 47 - Add Google support
-from sources.calendar import google, office365
+from sources.calendar import google, ics, office365
 # 48 - Add Slack support
 from sources.collaboration import slack, webex
 from targets import tuya
@@ -40,6 +40,7 @@ class StatusLight:
     slack_api: slack.SlackAPI = slack.SlackAPI()
     office_api: office365.OfficeAPI = office365.OfficeAPI()
     google_api: google.GoogleCalendarAPI = google.GoogleCalendarAPI()
+    ics_api: ics.Ics = ics.Ics()
 
     # Target Properties
     light: tuya.TuyaLight = tuya.TuyaLight()
@@ -134,6 +135,20 @@ class StatusLight:
                     'Requested Google, but could not find all environment variables!')
                 sys.exit(1)
 
+        # ICS Calendar support
+        if enum.StatusSource.ICS in self.local_env.selected_sources:
+            if self.local_env.get_ics():
+                self.logger.info('Requested ICS')
+                self.ics_api.url = self.local_env.ics_url
+                self.ics_api.cacheStore = self.local_env.ics_cache_store
+                self.ics_api.cacheLifetime = self.local_env.ics_cache_lifetime
+                # 81 - Make calendar lookahead configurable
+                self.ics_api.lookahead = self.local_env.calendar_lookahead
+            else:
+                self.logger.error(
+                    'Requested ICS, but could not find all environment variables!')
+                sys.exit(1)
+
         # Tuya
         self.light.device = self.local_env.tuya_device
         self.logger.debug('Retrieved TUYA_DEVICE variable: %s', self.light.device)
@@ -166,6 +181,7 @@ class StatusLight:
                     slack_status = enum.Status.UNKNOWN
                     office_status = enum.Status.UNKNOWN
                     google_status = enum.Status.UNKNOWN
+                    ics_status = enum.Status.UNKNOWN
 
                     logger_format = " {}: {} |"
                     logger_string = ""
@@ -198,6 +214,13 @@ class StatusLight:
                             logger_format.format(enum.StatusSource.GOOGLE.name.capitalize(),
                                                  google_status.name.lower())
 
+                    # ICS Status (based on calendar)
+                    if enum.StatusSource.ICS in self.local_env.selected_sources:
+                        ics_status = self.ics_api.get_current_status()
+                        logger_string += \
+                            logger_format.format(enum.StatusSource.ICS.name.capitalize(),
+                                                 ics_status.name.lower())
+
                     # 74: Log enums as names, not values
                     self.logger.debug(logger_string.lstrip().rstrip(' |'))
 
@@ -218,19 +241,24 @@ class StatusLight:
                     if (self.current_status in self.local_env.available_status or
                         self.current_status in self.local_env.off_status) \
                         and (office_status not in self.local_env.off_status
-                             or google_status not in self.local_env.off_status):
+                             or google_status not in self.local_env.off_status
+                             or ics_status not in self.local_env.off_status):
 
                         self.logger.debug('Using calendar-based status')
-                        # Office should take precedence over Google for now
+                        # Office should take precedence over Google, Google over ICS
                         # 74: Log enums as names, not values
                         if office_status != enum.Status.UNKNOWN:
                             self.logger.debug('Using office_status: %s',
                                          office_status.name.lower())
                             self.current_status = office_status
-                        else:
+                        elif google_status != enum.Status.UNKNOWN:
                             self.logger.debug('Using google_status: %s',
                                          google_status.name.lower())
                             self.current_status = google_status
+                        else:
+                            self.logger.debug('Using ics_status: %s',
+                                         ics_status.name.lower())
+                            self.current_status = ics_status
 
                     status_changed = False
                     if self.last_status != self.current_status:

--- a/status-light/targets/virtual.py
+++ b/status-light/targets/virtual.py
@@ -1,0 +1,56 @@
+"""Status-Light
+(c) 2020-2023 Nick Warner
+https://github.com/portableprogrammer/Status-Light/
+
+Virtual Light Target for testing
+"""
+
+import logging
+
+from utility import enum
+
+logger = logging.getLogger(__name__)
+
+
+class VirtualLight:
+    """Virtual light target that logs status changes for testing."""
+    _power: bool = False
+    _mode: str = 'white'
+    _color: str = 'ffffff'
+    _brightness: int = 128
+
+    def on(self):
+        """Turns on the light."""
+        logger.info('[Virtual] Light ON')
+        self._power = True
+        return True
+
+    def off(self):
+        """Turns off the light."""
+        logger.info('[Virtual] Light OFF')
+        self._power = False
+        return True
+
+    def get_status(self):
+        """Retrieves the current status of the virtual device."""
+        logger.info('[Virtual] Status: power=%s, mode=%s, color=%s, brightness=%s',
+                    self._power, self._mode, self._color, self._brightness)
+        return {'power': self._power, 'mode': self._mode,
+                'color': self._color, 'brightness': self._brightness}
+
+    def set_status(self, mode: enum.TuyaMode = enum.TuyaMode.WHITE,
+                   color: str = enum.Color.WHITE.value,
+                   brightness: int = 128) -> bool:
+        """Sets the virtual light status.
+
+        `mode`: `white`, `colour`
+        `color`: A hex-formatted RGB color (e.g. `rrggbb`)
+        `brightness`: An `int` between 0 and 255 inclusive
+        """
+        self._power = True
+        self._mode = mode.value
+        self._color = color
+        self._brightness = brightness
+        logger.info('[Virtual] set_status(mode=%s, color=%s, brightness=%s)',
+                    mode.value, color, brightness)
+        return True

--- a/status-light/targets/virtual.py
+++ b/status-light/targets/virtual.py
@@ -1,5 +1,5 @@
 """Status-Light
-(c) 2020-2023 Nick Warner
+(c) 2020-2025 Nick Warner
 https://github.com/portableprogrammer/Status-Light/
 
 Virtual Light Target for testing

--- a/status-light/utility/enum.py
+++ b/status-light/utility/enum.py
@@ -19,6 +19,8 @@ class StatusSource(enum.IntEnum):
     GOOGLE = enum.auto()
     # 48 - Add Slack suport
     SLACK = enum.auto()
+    # ICS Calendar support
+    ICS = enum.auto()
 
     @classmethod
     def _missing_(cls, value):

--- a/status-light/utility/env.py
+++ b/status-light/utility/env.py
@@ -56,6 +56,9 @@ class Environment:
     ics_cache_store: str = '~'
     ics_cache_lifetime: int = 30
 
+    # Target selection
+    target: str = 'tuya'
+
     # 38 - Working Elsewhere isn't handled
     off_status: list[enum.Status] = [enum.Status.INACTIVE,
                                      enum.Status.OUTOFOFFICE,
@@ -199,6 +202,14 @@ class Environment:
             logger.warning('ICS_CACHELIFETIME must be between 5 and 60 minutes!')
             self.ics_cache_lifetime = 30
         return self.ics_url != ''
+
+    def get_target(self) -> bool:
+        """Retrieves and validates the `TARGET` variable."""
+        self.target = os.environ.get('TARGET', self.target).lower()
+        if self.target not in ('tuya', 'virtual'):
+            logger.warning('TARGET must be "tuya" or "virtual"!')
+            return False
+        return True
 
     def get_colors(self) -> bool:
         """Retrieves and validates the `*_COLOR` variables."""

--- a/status-light/utility/env.py
+++ b/status-light/utility/env.py
@@ -51,6 +51,11 @@ class Environment:
     google_credential_store: str = './utility/api/calendar/google'
     google_token_store: str = '~'
 
+    # ICS Calendar support
+    ics_url: str = ''
+    ics_cache_store: str = '~'
+    ics_cache_lifetime: int = 30
+
     # 38 - Working Elsewhere isn't handled
     off_status: list[enum.Status] = [enum.Status.INACTIVE,
                                      enum.Status.OUTOFOFFICE,
@@ -180,6 +185,20 @@ class Environment:
         self.google_token_store = os.environ.get('GOOGLE_TOKENSTORE',
                                                  self.google_token_store)
         return ('' not in [self.google_credential_store, self.google_token_store])
+
+    def get_ics(self) -> bool:
+        """Retrieves and validates the `ICS_*` variables."""
+        # ICS_URL is required and may contain secrets
+        self.ics_url = util.get_env_or_secret('ICS_URL', '')
+        self.ics_cache_store = os.environ.get('ICS_CACHESTORE', self.ics_cache_store)
+        self.ics_cache_lifetime = util.try_parse_int(
+            os.environ.get('ICS_CACHELIFETIME', ''),
+            self.ics_cache_lifetime)
+        # Validate cache lifetime is within 5-60 minutes
+        if self.ics_cache_lifetime < 5 or self.ics_cache_lifetime > 60:
+            logger.warning('ICS_CACHELIFETIME must be between 5 and 60 minutes!')
+            self.ics_cache_lifetime = 30
+        return self.ics_url != ''
 
     def get_colors(self) -> bool:
         """Retrieves and validates the `*_COLOR` variables."""


### PR DESCRIPTION
## Summary

- Add ICS/iCalendar calendar source with RFC 5545 compliant status detection
- Add virtual light target for testing without hardware
- Add `TARGET` environment variable to select output target (tuya or virtual)

### ICS Calendar Source
- Fetches and caches ICS files from any URL
- RFC 5545 compliant status mapping based on `TRANSP` and `STATUS` properties
- Supports `free`, `tentative`, and `busy` statuses
- Configurable cache lifetime (`ICS_CACHELIFETIME`) and lookahead (`CALENDAR_LOOKAHEAD`)
- Uses `icalendar` + `recurring-ical-events` libraries for proper timezone and recurring event handling
- Correctly handles cross-timezone events (e.g., Pacific time events detected when running in Mountain time)

### Virtual Light Target
- Logs status changes instead of communicating with hardware
- Enable with `TARGET=virtual` (no `TUYA_DEVICE` required)
- Useful for development and testing

## Test plan

- [x] Test ICS source with various calendar URLs
- [x] Verify RFC 5545 status mapping (transparent, cancelled, tentative, confirmed events)
- [x] Test cross-timezone event detection (Pacific events in Mountain timezone)
- [x] Test virtual light target logs correctly
- [x] Verify `TARGET=tuya` still requires `TUYA_DEVICE`

🤖 Generated with [Claude Code](https://claude.ai/code)